### PR TITLE
Fix search broken by Cloudflare Bot Management

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,7 +49,8 @@
       {
         "title": "Splicedd",
         "width": 1200,
-        "height": 600
+        "height": 600,
+        "additionalBrowserArgs": "--disable-web-security"
       }
     ],
     "security": {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,10 +4,8 @@ import { Button } from "@nextui-org/button";
 import { SearchIcon, ChevronDownIcon } from '@nextui-org/shared-icons'
 import { WrenchIcon } from "@heroicons/react/20/solid";
 import { CircularProgress, Input, Modal, Pagination, Popover, PopoverContent, PopoverTrigger, Radio, RadioGroup, Select, SelectItem, useDisclosure } from "@nextui-org/react";
-import { fetch } from '@tauri-apps/api/http';
-
 import { cfg } from "../config";
-import { GRAPHQL_URL, SpliceSample, SpliceSearchResponse, createSearchRequest } from "../splice/api";
+import { SpliceSample, SpliceSearchResponse, createSearchRequest } from "../splice/api";
 import { ChordType, MusicKey, SpliceSampleType, SpliceSortBy, SpliceTag } from "../splice/entities";
 
 import SampleListEntry from "./components/SampleListEntry";
@@ -142,19 +140,18 @@ function App() {
 
       setSearchLoading(true);
 
-      const resp = await fetch<SpliceSearchResponse>(GRAPHQL_URL, {
+      const resp = await window.fetch("https://surfaces-graphql.splice.com/graphql", {
         method: "POST",
-        body: {
-          type: "Json",
-          payload
-        }
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
       });
 
       setSearchLoading(false);
 
       pbCtx.cancellation?.(); // stop any sample that's currently playing
 
-      const data = resp.data.data.assetsSearch;
+      const respData: SpliceSearchResponse = await resp.json();
+      const data = respData.data.assetsSearch;
 
       setResults(data.items);
       setResultCount(data.response_metadata.records);


### PR DESCRIPTION
## What's broken

Splice added Cloudflare Bot Management to their GraphQL API endpoint (`surfaces-graphql.splice.com/graphql`). Requests from Tauri's built-in HTTP module are blocked with **HTTP 403** because Cloudflare detects non-browser TLS/HTTP2 fingerprints - adding browser-like headers alone does not help since the block happens at the TLS/HTTP2 layer.

## Fix

Route the GraphQL request through **`window.fetch`** (WebView2 native Chromium fetch) instead of `@tauri-apps/api/http`. WebView2 uses Chrome's TLS and HTTP2 stack, which passes Cloudflare's checks transparently.

Since the request originates from `tauri://localhost`, it would normally be blocked by CORS. This is resolved by adding `--disable-web-security` to `additionalBrowserArgs` in `tauri.conf.json`.

## Changes

- `src/ui/App.tsx` - replace `fetch` from `@tauri-apps/api/http` with `window.fetch`
- `src-tauri/tauri.conf.json` - add `additionalBrowserArgs: --disable-web-security` to the window config

Fixes #15