### PR TITLE
feat: add seekable waveform previews and redesign BPM filter

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
     "core:default",
     "shell:allow-open",
     "dialog:default",
+    "drag:default",
     {
       "identifier": "fs:allow-exists",
       "allow": [{ "path": "$APPCONFIG/**" }]
@@ -26,7 +27,8 @@
       "identifier": "http:default",
       "allow": [
         { "url": "https://spliceproduction.s3.*.amazonaws.com/**" },
-        { "url": "https://surfaces-graphql.splice.com/**" }
+        { "url": "https://*.amazonaws.com/spliceblob.splice.com/**" },
+        { "url": "https://*.splice.com/**" }
       ]
     }
   ]

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { Button, ListBox, ListBoxItem, ListBoxItemIndicator, ModalBackdrop, ModalCloseTrigger, ModalContainer, ModalDialog, Pagination, PaginationContent, PaginationEllipsis, PaginationItem, PaginationLink, PaginationNext, PaginationNextIcon, PaginationPrevious, PaginationPreviousIcon, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle, useOverlayState } from "@heroui/react";
-import { InputGroup, InputGroupInput, InputGroupPrefix, InputGroupSuffix, Label, Modal, Popover, PopoverArrow, PopoverContent, PopoverDialog, Radio, RadioControl, RadioGroup, RadioIndicator, Select, SelectIndicator, SelectPopover, SelectTrigger, SelectValue, TextField } from "@heroui/react";
+import { InputGroup, InputGroupInput, InputGroupPrefix, Modal, Popover, PopoverArrow, PopoverContent, PopoverDialog, Select, SelectIndicator, SelectPopover, SelectTrigger, SelectValue } from "@heroui/react";
 import { SearchIcon, ChevronDownIcon } from '@heroui/shared-icons'
 import { WrenchIcon } from "@heroicons/react/20/solid";
 import { emit, listen } from "@tauri-apps/api/event";
@@ -12,6 +12,7 @@ import { ChordType, MusicKey, SpliceSampleType, SpliceSortBy, SpliceTag } from "
 import SampleListEntry from "./components/SampleListEntry";
 import SettingsModalContent from "./components/SettingsModalContent";
 import KeyScaleSelection from "./components/KeyScaleSelection";
+import BpmSelection, { BpmFilter, BpmFilterType } from "./components/BpmSelection";
 import { SamplePlaybackCancellation, SamplePlaybackContext } from "./playback";
 
 /**
@@ -72,12 +73,9 @@ function App() {
     defaultOpen: !cfg().configured
   });
 
-  const [bpmType, setBpmType] = useState<"exact" | "range">("exact");
-  const [bpm, setBpm] = useState<{
-    minBpm?: number,
-    maxBpm?: number,
-    bpm?: string
-  }>();
+  const [bpmType, setBpmType] = useState<BpmFilterType>("exact");
+  const [bpm, setBpm] = useState<BpmFilter>();
+  const [bpmOpen, setBpmOpen] = useState(false);
 
   const [query, setQuery] = useState("");
 
@@ -282,9 +280,11 @@ function App() {
           placeholder="Instruments"
           value={Array.from(instruments)}
           onChange={x => setInstruments(new Set(x as string[]))}
+          className="w-44 shrink-0"
+          fullWidth
         >
-          <SelectTrigger onPress={ensureContraintsGathered}>
-            <SelectValue />
+          <SelectTrigger onPress={ensureContraintsGathered} className="max-w-full">
+            <SelectValue className="truncate" />
             <SelectIndicator />
           </SelectTrigger>
           <SelectPopover>
@@ -299,9 +299,11 @@ function App() {
           placeholder="Genres"
           value={Array.from(genres)}
           onChange={x => setGenres(new Set(x as string[]))}
+          className="w-44 shrink-0"
+          fullWidth
         >
-          <SelectTrigger onPress={ensureContraintsGathered}>
-            <SelectValue />
+          <SelectTrigger onPress={ensureContraintsGathered} className="max-w-full">
+            <SelectValue className="truncate" />
             <SelectIndicator />
           </SelectTrigger>
           <SelectPopover>
@@ -316,10 +318,11 @@ function App() {
           placeholder="Tags"
           value={tags.map(x => x.uuid)}
           onChange={x => updateTagState(new Set(x as string[]))}
-          className="w-1/2"
+          className="w-1/2 min-w-0"
+          fullWidth
         >
-          <SelectTrigger>
-            <SelectValue />
+          <SelectTrigger className="max-w-full">
+            <SelectValue className="truncate" />
             <SelectIndicator />
           </SelectTrigger>
           <SelectPopover>
@@ -349,7 +352,7 @@ function App() {
           </PopoverContent>
         </Popover>
 
-        <Popover>
+        <Popover isOpen={bpmOpen} onOpenChange={setBpmOpen}>
           <Button variant="outline" className="w-96">
             { (bpmType == "exact" && bpm?.bpm
                 ? `${bpm?.bpm} BPM`
@@ -363,65 +366,20 @@ function App() {
 
           <PopoverContent placement="bottom">
             <PopoverArrow />
-            <PopoverDialog className="p-8 flex flex-col items-start justify-start">
-              <RadioGroup
-                aria-label="BPM filter type"
-                value={bpmType}
-                onChange={v => setBpmType(v as "exact" | "range")}
-              >
-                <Radio value="exact">
-                  <RadioControl><RadioIndicator /></RadioControl>
-                  Exact
-                </Radio>
-                <Radio value="range">
-                  <RadioControl><RadioIndicator /></RadioControl>
-                  Range
-                </Radio>
-              </RadioGroup>
-
-              <br/>
-
-              {
-                bpmType == "exact" ? (
-                  <div>
-                    <TextField
-                      value={bpm?.bpm?.toString() ?? ""}
-                      onChange={v => setBpm({ ...bpm, bpm: v })}
-                    >
-                      <Label>BPM</Label>
-                      <InputGroup>
-                        <InputGroupInput type="number" placeholder="(tempo)" />
-                      </InputGroup>
-                    </TextField>
-                  </div>
-                ) : (
-                  <div className="flex flex-col align-middle justify-center items-center gap-2">
-                    <TextField
-                      value={bpm?.minBpm?.toString() ?? ""}
-                      onChange={v => setBpm({ ...bpm, minBpm: parseInt(v) })}
-                    >
-                      <Label>Minimum</Label>
-                      <InputGroup>
-                        <InputGroupInput type="number" placeholder="(tempo)" />
-                        <InputGroupSuffix>BPM</InputGroupSuffix>
-                      </InputGroup>
-                    </TextField>
-
-                    <div className="align-middle">to</div>
-
-                    <TextField
-                      value={bpm?.maxBpm?.toString() ?? ""}
-                      onChange={v => setBpm({ ...bpm, maxBpm: parseInt(v) })}
-                    >
-                      <Label>Maximum</Label>
-                      <InputGroup>
-                        <InputGroupInput type="number" placeholder="(tempo)" />
-                        <InputGroupSuffix>BPM</InputGroupSuffix>
-                      </InputGroup>
-                    </TextField>
-                  </div>
-                )
-              }
+            <PopoverDialog className="p-6">
+              <BpmSelection
+                bpmType={bpmType}
+                bpm={bpm}
+                onSave={(type, newBpm) => {
+                  setBpmType(type);
+                  setBpm(newBpm);
+                  setBpmOpen(false);
+                }}
+                onClear={() => {
+                  setBpm(undefined);
+                  setBpmOpen(false);
+                }}
+              />
             </PopoverDialog>
           </PopoverContent>
         </Popover>

--- a/src/ui/components/BpmSelection.tsx
+++ b/src/ui/components/BpmSelection.tsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+import {
+  Button, InputGroup, InputGroupInput, Link,
+  Slider, SliderFill, SliderThumb, SliderTrack,
+  Tab, TabIndicator, TabList, TabPanel, Tabs, TextField
+} from "@heroui/react";
+
+export type BpmFilterType = "exact" | "range";
+
+export interface BpmFilter {
+  minBpm?: number;
+  maxBpm?: number;
+  bpm?: string;
+}
+
+const MIN_BPM = 1;
+const MAX_BPM = 300;
+
+const clampBpm = (x: number) => Math.min(Math.max(x, MIN_BPM), MAX_BPM);
+
+function parseBpmInput(value: string): number | null {
+  const parsed = parseInt(value);
+  return isNaN(parsed) ? null : clampBpm(parsed);
+}
+
+/**
+ * Provides the contents of the BPM filter popover: a "Range"/"Exact" tab pair,
+ * each with a slider and matching text inputs, applied via the "Save" button.
+ */
+export default function BpmSelection({
+  bpmType, bpm, onSave, onClear
+}: {
+  bpmType: BpmFilterType,
+  bpm: BpmFilter | undefined,
+  onSave: (type: BpmFilterType, bpm: BpmFilter) => void,
+  onClear: () => void
+}) {
+  const [tab, setTab] = useState<BpmFilterType>(bpmType);
+
+  const [minBpm, setMinBpm] = useState<number | null>(bpm?.minBpm ?? null);
+  const [maxBpm, setMaxBpm] = useState<number | null>(bpm?.maxBpm ?? null);
+  const [exactBpm, setExactBpm] = useState<number | null>(
+    bpm?.bpm ? parseBpmInput(bpm.bpm) : null
+  );
+
+  const canSave = tab == "exact"
+    ? exactBpm != null
+    : minBpm != null || maxBpm != null;
+
+  function handleSave() {
+    if (tab == "exact") {
+      onSave("exact", { bpm: exactBpm!.toString() });
+    } else {
+      onSave("range", {
+        minBpm: minBpm ?? MIN_BPM,
+        maxBpm: maxBpm ?? MAX_BPM
+      });
+    }
+  }
+
+  const sliderScale = () => (
+    <div className="flex justify-between w-full text-sm text-muted">
+      <span>{MIN_BPM}</span>
+      <span>{MAX_BPM}</span>
+    </div>
+  );
+
+  const bottomRow = () => (
+    <div className="flex justify-between items-center w-full pt-2">
+      <Link href="#" onClick={onClear}>Clear</Link>
+      <Button isDisabled={!canSave} onClick={handleSave}>Save</Button>
+    </div>
+  );
+
+  const bpmInput = (
+    value: number | null,
+    onChange: (x: number | null) => void,
+    placeholder: string
+  ) => (
+    <TextField
+      aria-label={placeholder}
+      value={value?.toString() ?? ""}
+      onChange={v => onChange(parseBpmInput(v))}
+      className="w-16"
+    >
+      <InputGroup className="border border-border">
+        <InputGroupInput type="number" placeholder={placeholder} />
+      </InputGroup>
+    </TextField>
+  );
+
+  return (
+    <Tabs
+      className="w-64"
+      selectedKey={tab}
+      onSelectionChange={x => setTab(x as BpmFilterType)}
+    >
+      <TabList aria-label="BPM filter type" className="w-full">
+        <Tab id="range" className="flex-1 justify-center">Range<TabIndicator /></Tab>
+        <Tab id="exact" className="flex-1 justify-center">Exact<TabIndicator /></Tab>
+      </TabList>
+
+      <TabPanel id="range">
+        <div className="flex flex-col gap-4 pt-4">
+          <div className="flex justify-between items-center">
+            <h4 className="text-base font-medium">Range</h4>
+            <div className="flex items-center gap-2">
+              {bpmInput(minBpm, setMinBpm, "Min")}
+              <span className="text-muted">-</span>
+              {bpmInput(maxBpm, setMaxBpm, "Max")}
+            </div>
+          </div>
+
+          <Slider
+            aria-label="BPM range"
+            minValue={MIN_BPM} maxValue={MAX_BPM}
+            value={[minBpm ?? MIN_BPM, maxBpm ?? MAX_BPM]}
+            onChange={v => {
+              const [min, max] = v as number[];
+              setMinBpm(min);
+              setMaxBpm(max);
+            }}
+          >
+            <SliderTrack>
+              <SliderFill />
+              <SliderThumb index={0} aria-label="Minimum BPM" />
+              <SliderThumb index={1} aria-label="Maximum BPM" />
+            </SliderTrack>
+          </Slider>
+
+          {sliderScale()}
+          {bottomRow()}
+        </div>
+      </TabPanel>
+
+      <TabPanel id="exact">
+        <div className="flex flex-col gap-4 pt-4">
+          <div className="flex justify-between items-center">
+            <h4 className="text-base font-medium">Exact</h4>
+            {bpmInput(exactBpm, setExactBpm, "BPM")}
+          </div>
+
+          <Slider
+            aria-label="Exact BPM"
+            minValue={MIN_BPM} maxValue={MAX_BPM}
+            value={exactBpm ?? MIN_BPM}
+            onChange={v => setExactBpm(v as number)}
+          >
+            <SliderTrack>
+              <SliderFill />
+              <SliderThumb aria-label="BPM" />
+            </SliderTrack>
+          </Slider>
+
+          {sliderScale()}
+          {bottomRow()}
+        </div>
+      </TabPanel>
+    </Tabs>
+  );
+}

--- a/src/ui/components/SampleListEntry.tsx
+++ b/src/ui/components/SampleListEntry.tsx
@@ -4,7 +4,7 @@ import { MusicalNoteIcon } from "@heroicons/react/20/solid";
 import { PlayIcon, StopIcon } from "@heroicons/react/20/solid";
 
 import { fetch } from "@tauri-apps/plugin-http";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { startDrag } from "@crabnebula/tauri-plugin-drag";
 
 import * as wav from "node-wav";
@@ -16,6 +16,7 @@ import { SamplePlaybackContext } from "../playback";
 import { SpliceTag } from "../../splice/entities";
 import { SpliceSample } from "../../splice/api";
 import { decodeSpliceAudio } from "../../splice/decoder";
+import Waveform from "./Waveform";
 
 const getChordTypeDisplay = (type: string | null) =>
   type == null ? "" : type == "major" ? " Major" : " Minor";
@@ -34,31 +35,71 @@ export default function SampleListEntry(
 ) {
   const [fgLoading, setFgLoading] = useState(false);
   const [playing, setPlaying] = useState(false);
-  const audio = document.createElement("audio");
+  const [progress, setProgress] = useState(0);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  if (audioRef.current == null) {
+    audioRef.current = document.createElement("audio");
+  }
+
+  const audio = audioRef.current;
 
   const pack = sample.parents.items[0];
   const packCover = pack
     ? pack.files.find(x => x.asset_file_type_slug == "cover_image")?.url
     : "img/missing-cover.png";
 
-  let decodedSample: Uint8Array<ArrayBuffer> | null = null;
+  const waveformUrl = sample.files.find(x => x.asset_file_type_slug == "waveform")?.url;
 
-  let fetchAhead: Promise<Response> | null = null;
+  const decodedSample = useRef<Uint8Array<ArrayBuffer> | null>(null);
+
+  const fetchAhead = useRef<Promise<Response> | null>(null);
   function startFetching() {
-    if (fetchAhead != null)
+    if (fetchAhead.current != null)
       return;
 
     const file = sample.files.find(x => x.asset_file_type_slug == "preview_mp3")!;
 
-    fetchAhead = fetch(file.url);
+    fetchAhead.current = fetch(file.url);
   }
 
-  audio.onended = () => setPlaying(false);
+  audio.onended = () => {
+    setPlaying(false);
+    setProgress(0);
+  };
+
+  // While a sample is playing, keep its waveform's progress marker in
+  // sync with the audio element.
+  useEffect(() => {
+    if (!playing)
+      return;
+
+    let raf = requestAnimationFrame(function tick() {
+      setProgress(audio.duration > 0 ? audio.currentTime / audio.duration : 0);
+      raf = requestAnimationFrame(tick);
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [playing]);
 
   function stop() {
     audio.pause();
     audio.currentTime = 0;
     setPlaying(false);
+    setProgress(0);
+  }
+
+  async function ensurePlayable() {
+    if (audio.src != "")
+      return;
+
+    setFgLoading(true);
+    await ensureAudioDecoded();
+    setFgLoading(false);
+
+    audio.src = URL.createObjectURL(
+      new Blob([decodedSample.current!], { "type": "audio/mpeg" })
+    );
   }
 
   async function handlePlayClick() {
@@ -67,15 +108,7 @@ export default function SampleListEntry(
     if (playing)
       return;
 
-    if (audio.src == "") {
-      setFgLoading(true);
-      await ensureAudioDecoded();
-      setFgLoading(false);
-
-      audio.src = URL.createObjectURL(
-        new Blob([decodedSample!], { "type": "audio/mpeg" })
-      );
-    }
+    await ensurePlayable();
 
     audio.play();
     setPlaying(true);
@@ -83,17 +116,32 @@ export default function SampleListEntry(
     ctx.setCancellation(() => stop);
   }
 
+  async function handleSeek(target: number) {
+    if (!playing) {
+      ctx.cancellation?.();
+      await ensurePlayable();
+      audio.play();
+      setPlaying(true);
+      ctx.setCancellation(() => stop);
+    }
+
+    // The audio metadata might not be loaded yet right after setting the
+    // source, so we compute the seek time from the sample's known duration.
+    audio.currentTime = target * (sample.duration / 1000);
+    setProgress(target);
+  }
+
   async function ensureAudioDecoded() {
-    if (decodedSample != null)
+    if (decodedSample.current != null)
       return;
 
-    if (fetchAhead == null) {
+    if (fetchAhead.current == null) {
       startFetching();
     }
 
-    const resp = await fetchAhead!;
+    const resp = await fetchAhead.current!;
     const data = await resp.arrayBuffer();
-    decodedSample = decodeSpliceAudio(new Uint8Array(data));
+    decodedSample.current = decodeSpliceAudio(new Uint8Array(data));
   }
 
   const sanitizePath = (x: string) => x.replace(/[<>:"|?* ]/g, "_");
@@ -124,7 +172,9 @@ export default function SampleListEntry(
 
       const actx = new AudioContext();
 
-      const samples = await actx.decodeAudioData(decodedSample!.buffer);
+      // decodeAudioData detaches the buffer we give it, so pass a copy to
+      // keep the decoded sample usable for playback afterwards.
+      const samples = await actx.decodeAudioData(decodedSample.current!.buffer.slice(0));
       const channels: Float32Array[] = [];
 
       if (samples.length < 60 * 44100) {
@@ -194,7 +244,7 @@ export default function SampleListEntry(
       </div>
 
       { /* sample name + tags */}
-      <div className="grow" onMouseDown={handleDrag}>
+      <div className="flex-1 min-w-0" onMouseDown={handleDrag}>
         <div className="flex gap-1 max-w-[50vw] overflow-clip">
           {sample.name.split("/").pop()}
           <div className="text-muted">({sample.asset_category_slug})</div>
@@ -211,26 +261,35 @@ export default function SampleListEntry(
         ))}</div>
       </div>
 
-      { /* other metadata */}
-      <div className="flex gap-8" onMouseDown={handleDrag}>
-        {sample.key != null ?
-          <div className="flex items-center gap-2 font-semibold text-muted">
-            <MusicalNoteIcon className="w-4" />
-            <span>{`${sample.key.toUpperCase()}${getChordTypeDisplay(sample.chord_type)}`}</span>
-          </div>
-          : <></>}
+      { /* waveform preview */}
+      {waveformUrl &&
+        <Waveform
+          src={waveformUrl}
+          progress={progress}
+          onSeek={handleSeek}
+          className="w-40 h-10 shrink-0"
+        />}
 
-        <div className="flex items-center gap-2 font-semibold text-muted">
-          <ClockCircleLinearIcon />
+      { /* other metadata */}
+      <div className="grid grid-cols-3 gap-2 w-72 shrink-0" onMouseDown={handleDrag}>
+        <div className="flex items-center gap-2 font-semibold text-muted whitespace-nowrap">
+          <MusicalNoteIcon className="w-4 shrink-0" />
+          <span>
+            {sample.key != null
+              ? `${sample.key.toUpperCase()}${getChordTypeDisplay(sample.chord_type)}`
+              : "--"}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 font-semibold text-muted whitespace-nowrap">
+          <ClockCircleLinearIcon className="shrink-0" />
           <span>{`${(sample.duration / 1000).toFixed(2)}s`}</span>
         </div>
 
-        {sample.bpm != null ?
-          <div className="flex items-center gap-2 font-semibold text-muted">
-            <ClockSquareBoldIcon />
-            <span>{`${sample.bpm} BPM`}</span>
-          </div>
-          : <></>}
+        <div className="flex items-center gap-2 font-semibold text-muted whitespace-nowrap">
+          <ClockSquareBoldIcon className="shrink-0" />
+          <span>{sample.bpm != null ? `${sample.bpm} BPM` : "--"}</span>
+        </div>
       </div>
     </div>
   );

--- a/src/ui/components/Waveform.tsx
+++ b/src/ui/components/Waveform.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { fetch } from "@tauri-apps/plugin-http";
+
+/** The flat line shown in place of a waveform that hasn't loaded yet. */
+const EMPTY_WAVEFORM: number[] = new Array(64).fill(0);
+
+function waveformPath(data: number[]) {
+  const width = 1000;
+  const height = 200;
+  const midHeight = height / 2;
+  const step = width / data.length;
+
+  const path = [`M 0 ${midHeight}`];
+
+  // Top half of the waveform...
+  for (let i = 0; i < data.length; i++) {
+    path.push(`L ${(i * step).toFixed(2)} ${(midHeight - (data[i] * midHeight)).toFixed(2)}`);
+  }
+
+  // ...and the bottom half, mirrored.
+  for (let i = data.length - 1; i >= 0; i--) {
+    path.push(`L ${(i * step).toFixed(2)} ${(midHeight + (data[i] * midHeight)).toFixed(2)}`);
+  }
+
+  path.push("Z");
+  return path.join(" ");
+}
+
+/**
+ * Displays the amplitude waveform of a sample, given the URL to its Splice
+ * "waveform" asset file (a JSON array of normalized amplitudes). The waveform
+ * is fetched lazily, when the component first becomes visible.
+ */
+export default function Waveform(
+  { src, progress, onSeek, className }: {
+    src: string,
+
+    /** Playback progress, from 0 to 1. Determines how much of the waveform is highlighted. */
+    progress: number,
+
+    /** Called when the user clicks the waveform to seek. Receives the target progress, from 0 to 1. */
+    onSeek: (progress: number) => void,
+
+    className?: string
+  }
+) {
+  const gradientId = useId().replace(/:/g, "");
+  const container = useRef<HTMLDivElement | null>(null);
+  const [waveform, setWaveform] = useState<number[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const observer = new IntersectionObserver(async entries => {
+      if (!entries.some(x => x.isIntersecting))
+        return;
+
+      observer.disconnect();
+
+      const resp = await fetch(src);
+
+      // Splice serves these gzipped, but the plugin-http client doesn't always
+      // transparently decompress them like a browser fetch would.
+      let data: number[];
+      if (resp.headers.get("content-encoding") == "gzip") {
+        const stream = (await resp.blob()).stream()
+          .pipeThrough(new DecompressionStream("gzip"));
+
+        data = await new Response(stream).json();
+      } else {
+        data = await resp.json();
+      }
+
+      if (!cancelled) {
+        setWaveform(data);
+      }
+    });
+
+    observer.observe(container.current!);
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [src]);
+
+  function handleClick(ev: React.MouseEvent<HTMLDivElement>) {
+    if (waveform == null)
+      return;
+
+    const rect = ev.currentTarget.getBoundingClientRect();
+    onSeek(Math.min(Math.max((ev.clientX - rect.left) / rect.width, 0), 1));
+  }
+
+  return (
+    <div ref={container}
+      onClick={handleClick}
+      className={`cursor-pointer ${className ?? ""}`}
+      data-draggable="false"
+      role="slider"
+      aria-label="Seek within sample"
+      aria-valuemin={0} aria-valuemax={1} aria-valuenow={progress}
+    >
+      <svg
+        className={`size-full transition-transform duration-500 ${waveform == null ? "scale-y-0" : ""}`}
+        viewBox="0 0 1000 200"
+        preserveAspectRatio="none"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset={`${progress * 100}%`} stopColor="var(--accent)" />
+            <stop offset={`${progress * 100}%`} stopColor="var(--muted)" />
+          </linearGradient>
+        </defs>
+        <path d={waveformPath(waveform ?? EMPTY_WAVEFORM)} fill={`url(#${gradientId})`} />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds lazy-loaded waveform previews with click-to-seek to sample list entries, and replaces the BPM filter popover with a tabbed slider-based selector.