### PR TITLE
feat: filter samples by pack when clicking a pack cover

### DIFF
--- a/src/dev/mock.ts
+++ b/src/dev/mock.ts
@@ -102,8 +102,11 @@ const SAMPLES: SpliceSample[] = [
 export function mockSearch(body: string): string {
   const payload = JSON.parse(body);
   const query: string = payload.variables.filepath ?? "";
+  const parentUuid: string | undefined = payload.variables.parent_asset_uuid;
 
-  const items = SAMPLES.filter(x => x.name.toLowerCase().includes(query.toLowerCase()));
+  const items = SAMPLES
+    .filter(x => x.name.toLowerCase().includes(query.toLowerCase()))
+    .filter(x => parentUuid == null || x.parents.items[0]?.uuid == parentUuid);
 
   const response: SpliceSearchResponse = {
     data: {

--- a/src/splice/api.ts
+++ b/src/splice/api.ts
@@ -51,7 +51,9 @@ export interface SpliceSearchRequest extends SpliceRequest<{
   asset_category_slug?: SpliceSampleType,
   page?: number,
   key?: MusicKey,
-  chord_type?: ChordType
+  chord_type?: ChordType,
+  parent_asset_uuid?: string,
+  parent_asset_type?: "pack"
 }>{}
 
 export type SpliceSearchResponse = {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,10 +2,10 @@ import { useEffect, useRef, useState } from "react";
 
 import { Button, ListBox, ListBoxItem, ListBoxItemIndicator, ModalBackdrop, ModalCloseTrigger, ModalContainer, ModalDialog, Pagination, PaginationContent, PaginationEllipsis, PaginationItem, PaginationLink, PaginationNext, PaginationNextIcon, PaginationPrevious, PaginationPreviousIcon, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle, ToggleButton, useOverlayState } from "@heroui/react";
 import { InputGroup, InputGroupInput, InputGroupPrefix, Modal, Popover, PopoverContent, PopoverDialog, Select, SelectIndicator, SelectPopover, SelectTrigger, SelectValue } from "@heroui/react";
-import { ArrowUpDown, ChevronDown, Disc3, EllipsisVertical, Guitar, Layers, Metronome, Music2, Search, Wrench } from "lucide-react";
+import { ArrowUpDown, ChevronDown, Disc3, EllipsisVertical, Guitar, Layers, Metronome, Music2, Search, Wrench, X } from "lucide-react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { cfg } from "../config";
-import { SpliceSample, SpliceSearchResponse, createSearchRequest } from "../splice/api";
+import { SpliceSample, SpliceSamplePack, SpliceSearchResponse, createSearchRequest } from "../splice/api";
 import { ChordType, MusicKey, SpliceSampleType, SpliceSortBy, SpliceTag } from "../splice/entities";
 
 import SampleListEntry from "./components/SampleListEntry";
@@ -107,6 +107,8 @@ function App() {
   const [musicKey, setMusicKey] = useState<MusicKey | null>(null);
   const [chordType, setChordType] = useState<ChordType | null>(null);
 
+  const [packFilter, setPackFilter] = useState<SpliceSamplePack | null>(null);
+
   const [totalPages, setTotalPages] = useState(0);
   const [currentPage, setCurrentPage] = useState(0);
 
@@ -117,14 +119,15 @@ function App() {
   // when the user is filtering solely by tags, key, BPM, etc.
   const filtersActive =
     tags.length > 0 || instruments.size > 0 || genres.size > 0 ||
-    musicKey != null || chordType != null || bpm != null || sampleType != "any";
+    musicKey != null || chordType != null || bpm != null || sampleType != "any" ||
+    packFilter != null;
 
   useEffect(() => {
     updateSearch(query);
   }, [
     sortBy, bpm, bpmType, sampleType,
     instruments, genres, currentPage,
-    musicKey, chordType
+    musicKey, chordType, packFilter
   ]);
 
   const [smplCancellation, smplSetCancellation] = useState<SamplePlaybackCancellation | null>(null);
@@ -179,6 +182,15 @@ function App() {
     toggleTag(tag);
   }
 
+  function handlePackClick(pack: SpliceSamplePack) {
+    if (packFilter?.uuid == pack.uuid) {
+      return;
+    }
+
+    setPackFilter(pack);
+    setCurrentPage(1);
+  }
+
   async function updateSearch(newQuery: string, resetPage = false) {
       const payload = createSearchRequest(newQuery);
       payload.variables.sort = sortBy;
@@ -204,6 +216,11 @@ function App() {
 
       payload.variables.chord_type = chordType ?? undefined;
       payload.variables.key = musicKey ?? undefined;
+
+      if (packFilter != null) {
+        payload.variables.parent_asset_uuid = packFilter.uuid;
+        payload.variables.parent_asset_type = "pack";
+      }
 
       payload.variables.page = resetPage ? 1 : currentPage;
 
@@ -446,6 +463,39 @@ function App() {
         </div>
       }
 
+      { /* Active pack filter banner; visually distinct from the tag pills so
+           it's obvious results are narrowed down to a single pack. */ }
+      { packFilter != null &&
+        <div className="flex items-center gap-3 px-3 py-2 rounded-2xl bg-surface shadow-md">
+          <img
+            src={packFilter.files.find(x => x.asset_file_type_slug == "cover_image")?.url ?? "img/missing-cover.png"}
+            alt="" width={36} height={36}
+            className="rounded-sm object-cover shrink-0"
+            draggable={false}
+          />
+
+          <div className="flex-1 min-w-0 flex flex-col">
+            <span className="text-xs text-muted">
+              Filtering by pack
+            </span>
+            <span className="truncate font-medium">{packFilter.name}</span>
+          </div>
+
+          <button
+            type="button"
+            aria-label={`Stop filtering by ${packFilter.name}`}
+            onClick={() => {
+              setPackFilter(null);
+              setCurrentPage(1);
+            }}
+            className="flex items-center justify-center w-8 h-8 rounded-full shrink-0
+                       cursor-pointer transition-colors hover:bg-surface-tertiary"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      }
+
       {
         searchError != null
         ? <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-8">
@@ -486,7 +536,7 @@ function App() {
                               ${searchLoading ? "opacity-50 pointer-events-none" : ""}`}
               >
               { results.map(
-                x => <SampleListEntry key={x.uuid} sample={x} onTagClick={handleTagClick} ctx={pbCtx}/>
+                x => <SampleListEntry key={x.uuid} sample={x} onTagClick={handleTagClick} onPackClick={handlePackClick} ctx={pbCtx}/>
               ) }
               </div>
 

--- a/src/ui/components/SampleListEntry.tsx
+++ b/src/ui/components/SampleListEntry.tsx
@@ -12,7 +12,7 @@ import { join } from "@tauri-apps/api/path";
 import { cfg } from "../../config";
 import { SamplePlaybackContext } from "../playback";
 import { SpliceTag } from "../../splice/entities";
-import { SpliceSample } from "../../splice/api";
+import { SpliceSample, SpliceSamplePack } from "../../splice/api";
 import { decodeSpliceAudio } from "../../splice/decoder";
 import Waveform from "./Waveform";
 
@@ -20,15 +20,17 @@ const getChordTypeDisplay = (type: string | null) =>
   type == null ? "" : type == "major" ? " Major" : " Minor";
 
 export type TagClickHandler = (tag: SpliceTag) => void;
+export type PackClickHandler = (pack: SpliceSamplePack) => void;
 
 /**
  * Provides a view describing a Splice sample.
  */
 export default function SampleListEntry(
-  { sample, ctx, onTagClick }: {
+  { sample, ctx, onTagClick, onPackClick }: {
     sample: SpliceSample,
     ctx: SamplePlaybackContext,
-    onTagClick: TagClickHandler
+    onTagClick: TagClickHandler,
+    onPackClick: PackClickHandler
   }
 ) {
   const [fgLoading, setFgLoading] = useState(false);
@@ -235,19 +237,26 @@ export default function SampleListEntry(
       <div className="flex items-center gap-3 shrink-0">
         <Tooltip>
           <TooltipTrigger>
-            <a href={`https://splice.com/sounds/labels/${pack.permalink_base_url}`} target="_blank">
+            <button
+              type="button"
+              onClick={() => onPackClick(pack)}
+              aria-label={`Show samples from ${pack.name}`}
+              data-draggable="false"
+              className="cursor-pointer"
+            >
               <img
                 src={packCover} alt={pack.name}
                 width={36} height={36}
                 className="rounded-sm object-cover"
                 draggable={false}
               />
-            </a>
+            </button>
           </TooltipTrigger>
           <TooltipContent>
             <div className="flex flex-col gap-2 p-3 max-w-40">
               <img src={packCover} alt={pack.name} width={128} height={128} className="rounded-lg" />
               <span className="text-sm font-medium">{pack.name}</span>
+              <span className="text-xs text-muted">Click to show samples from this pack</span>
             </div>
           </TooltipContent>
         </Tooltip>


### PR DESCRIPTION
Clicking a sample's pack cover now filters results to that pack instead of opening splice.com, with a dismissible banner showing the active pack filter.