### PR TITLE
feat: add in-app update checker with changelog modal

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod files;
+mod updater;
 
 use tauri::{WebviewUrl, WebviewWindowBuilder};
 
@@ -113,7 +114,9 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             files::write_sample_file,
             files::file_exists,
-            files::create_placeholder_file
+            files::create_placeholder_file,
+            updater::fetch_releases,
+            updater::install_update
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,0 +1,95 @@
+use std::io::Write;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_http::reqwest;
+use tauri_plugin_shell::ShellExt;
+
+const RELEASES_API_URL: &str = "https://api.github.com/repos/ascpixi/splicedd/releases";
+const DOWNLOAD_URL_PREFIX: &str = "https://github.com/ascpixi/splicedd/releases/download/";
+
+/// Fetches the metadata of the project's GitHub releases, newest first. The raw
+/// release JSON array is returned to the frontend, which decides whether an
+/// update should be offered and builds the changelog from the release notes.
+///
+/// This runs on the Rust side (rather than as a webview `fetch`) because the
+/// GitHub API rejects requests without a `User-Agent` header, which webviews
+/// don't allow overriding.
+#[tauri::command]
+pub async fn fetch_releases() -> Result<serde_json::Value, String> {
+    let resp = reqwest::Client::new()
+        .get(RELEASES_API_URL)
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "splicedd")
+        .send().await
+        .map_err(|e| format!("Failed to contact GitHub: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("GitHub returned HTTP {}", resp.status()));
+    }
+
+    let body = resp.text().await
+        .map_err(|e| format!("Failed to read the GitHub response: {e}"))?;
+
+    serde_json::from_str(&body)
+        .map_err(|e| format!("Failed to parse the GitHub response: {e}"))
+}
+
+#[derive(Clone, Serialize)]
+struct DownloadProgress {
+    downloaded: u64,
+    total: Option<u64>,
+}
+
+/// Downloads the installer at `url` (which must point to a splicedd GitHub
+/// release asset) into the temp directory, launches it, and exits the app so
+/// the installer can replace our files.
+#[tauri::command]
+pub async fn install_update(app: AppHandle, url: String) -> Result<(), String> {
+    // The frontend only ever passes asset URLs from our own releases; this is
+    // just a backstop so this command can't be used to run arbitrary files.
+    if !url.starts_with(DOWNLOAD_URL_PREFIX) {
+        return Err("Refusing to download an update from an unknown URL".into());
+    }
+
+    let file_name = url.rsplit('/').next().unwrap_or_default();
+    if file_name.is_empty() || file_name.contains("..") {
+        return Err("Malformed download URL".into());
+    }
+
+    let mut resp = reqwest::Client::new()
+        .get(&url)
+        .header("User-Agent", "splicedd")
+        .send().await
+        .map_err(|e| format!("Failed to start the download: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("GitHub returned HTTP {}", resp.status()));
+    }
+
+    let total = resp.content_length();
+    let path = std::env::temp_dir().join(file_name);
+
+    let mut file = std::fs::File::create(&path)
+        .map_err(|e| format!("Failed to create {}: {e}", path.display()))?;
+
+    let mut downloaded: u64 = 0;
+    while let Some(chunk) = resp.chunk().await.map_err(|e| format!("Download failed: {e}"))? {
+        file.write_all(&chunk)
+            .map_err(|e| format!("Failed to write the installer: {e}"))?;
+
+        downloaded += chunk.len() as u64;
+        let _ = app.emit("update-download-progress", DownloadProgress { downloaded, total });
+    }
+
+    drop(file);
+
+    // `Shell::open` is deprecated in favor of the opener plugin, but it works
+    // fine for launching installers and saves us from pulling in another plugin.
+    #[allow(deprecated)]
+    app.shell().open(path.to_string_lossy(), None)
+        .map_err(|e| format!("Failed to launch the installer: {e}"))?;
+
+    app.exit(0);
+    Ok(())
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,10 @@ export interface SpliceddConfig {
   sampleDir: string;
   placeholders: boolean;
   darkMode: boolean;
+  checkUpdates: boolean;
+
+  /** The release tag (e.g. "v1.2.0") the user chose to skip, if any. */
+  skippedUpdateVersion: string;
 
   configured: boolean;
 }
@@ -20,6 +24,8 @@ function defaultCfg(): SpliceddConfig {
     sampleDir: "",
     darkMode: true,
     placeholders: false,
+    checkUpdates: true,
+    skippedUpdateVersion: "",
     configured: false
   }
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -10,6 +10,8 @@ import { ChordType, MusicKey, SpliceSampleType, SpliceSortBy, SpliceTag } from "
 
 import SampleListEntry from "./components/SampleListEntry";
 import SettingsModalContent from "./components/SettingsModalContent";
+import UpdateModal from "./components/UpdateModal";
+import { UpdateInfo, checkForUpdates } from "../updater";
 import KeyScaleSelection from "./components/KeyScaleSelection";
 import BpmSelection, { BpmFilter, BpmFilterType } from "./components/BpmSelection";
 import { SamplePlaybackCancellation, SamplePlaybackContext } from "./playback";
@@ -114,6 +116,14 @@ function App() {
 
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
+
+  const [update, setUpdate] = useState<UpdateInfo | null>(null);
+
+  useEffect(() => {
+    checkForUpdates()
+      .then(setUpdate)
+      .catch(err => console.error("Update check failed:", err));
+  }, []);
 
   // Results should be visible not only when a text query is entered, but also
   // when the user is filtering solely by tags, key, BPM, etc.
@@ -283,6 +293,10 @@ function App() {
           </ModalContainer>
         </ModalBackdrop>
       </Modal>
+
+      { update != null &&
+        <UpdateModal update={update} onDismiss={() => setUpdate(null)} />
+      }
 
       <div className="flex gap-2">
         <InputGroup className="flex-1">

--- a/src/ui/components/SettingsModalContent.tsx
+++ b/src/ui/components/SettingsModalContent.tsx
@@ -35,6 +35,7 @@ export default function SettingsModalContent({ onClose }: { onClose: () => void 
   const sampleDir = useCfgSyncedState<string>("sampleDir");
   const placeholders = useCfgSyncedState<boolean>("placeholders");
   const darkMode = useCfgSyncedState<boolean>("darkMode");
+  const checkUpdates = useCfgSyncedState<boolean>("checkUpdates");
 
   function closeFirstTimeSetup() {
     mutateCfg({ configured: true });
@@ -97,6 +98,20 @@ export default function SettingsModalContent({ onClose }: { onClose: () => void 
                 isSelected={ cfg().placeholders }
                 onChange={ x => mutateCfgSync(x, placeholders) }
                 aria-label="Enable placeholder files"
+              >
+                <SwitchControl><SwitchThumb /></SwitchControl>
+              </Switch>
+            }
+          />
+
+          <SettingRow
+            title="Check for updates"
+            description="Ask to update when a new version of Splicedd is available."
+            control={
+              <Switch
+                isSelected={ cfg().checkUpdates }
+                onChange={ x => mutateCfgSync(x, checkUpdates) }
+                aria-label="Enable update checks"
               >
                 <SwitchControl><SwitchThumb /></SwitchControl>
               </Switch>

--- a/src/ui/components/UpdateModal.tsx
+++ b/src/ui/components/UpdateModal.tsx
@@ -1,0 +1,273 @@
+import { Fragment, useEffect, useState } from "react";
+import { Button, Modal, ModalBackdrop, ModalBody, ModalCloseTrigger, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, ModalIcon } from "@heroui/react";
+import { ArrowDownToLine } from "lucide-react";
+import { listen } from "@tauri-apps/api/event";
+import { open } from "@tauri-apps/plugin-shell";
+
+import { ReleaseNotes, UpdateInfo, disableUpdateChecks, installUpdate, skipUpdate } from "../../updater";
+
+/**
+ * A dialog shown on startup when a newer release of Splicedd is available.
+ * Lets the user update in place, skip the offered version, dismiss the
+ * dialog until the next launch, or turn off update checks altogether.
+ */
+export default function UpdateModal({ update, onDismiss }: {
+  update: UpdateInfo,
+  onDismiss: () => void
+}) {
+  const [downloading, setDownloading] = useState(false);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unlisten = listen<{ downloaded: number, total: number | null }>(
+      "update-download-progress",
+      ev => setProgress(ev.payload.total ? ev.payload.downloaded / ev.payload.total : null)
+    );
+
+    return () => { unlisten.then(x => x()); };
+  }, []);
+
+  async function handleUpdate() {
+    setDownloading(true);
+    setError(null);
+
+    try {
+      // If this succeeds, the installer is running and the app is about to exit.
+      await installUpdate(update);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setDownloading(false);
+      setProgress(null);
+    }
+  }
+
+  function handleSkip() {
+    skipUpdate(update);
+    onDismiss();
+  }
+
+  function handleDisable() {
+    disableUpdateChecks();
+    onDismiss();
+  }
+
+  return (
+    <Modal isOpen onOpenChange={open => { if (!open && !downloading) onDismiss(); }}>
+      <ModalBackdrop>
+        <ModalContainer size="lg">
+          <ModalDialog>
+            { !downloading && <ModalCloseTrigger /> }
+
+            <ModalHeader className="flex-row items-center gap-3">
+              <ModalIcon className="bg-default text-foreground">
+                <ArrowDownToLine className="size-5" />
+              </ModalIcon>
+              <div className="flex flex-col min-w-0">
+                <ModalHeading className="text-base font-semibold tracking-tight">
+                  Update available
+                </ModalHeading>
+                <p className="text-sm text-muted">
+                  Splicedd {update.version} is out. You're on {update.currentVersion}.
+                </p>
+              </div>
+            </ModalHeader>
+
+            <ModalBody className="flex flex-col gap-4">
+              { update.changelog.length > 0 &&
+                <Changelog releases={update.changelog} />
+              }
+
+              { update.installerUrl == null &&
+                <p className="text-sm text-muted">
+                  No installer for this platform was found in the release, so updating opens the release page in your browser.
+                </p>
+              }
+
+              { error != null &&
+                <p className="text-sm text-danger">
+                  Something went wrong while updating: {error}
+                </p>
+              }
+            </ModalBody>
+
+            <ModalFooter className="flex-col items-stretch gap-4">
+              <div className="flex gap-2 justify-center">
+                <Button variant="outline" isDisabled={downloading} onClick={handleSkip}>
+                  Skip this version
+                </Button>
+                <Button variant="outline" isDisabled={downloading} onClick={onDismiss}>
+                  Later
+                </Button>
+                <Button variant="primary" isDisabled={downloading} onClick={handleUpdate}>
+                  { downloading
+                    ? progress != null
+                      ? `Downloading... ${Math.round(progress * 100)}%`
+                      : "Downloading..."
+                    : "Update now" }
+                </Button>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleDisable}
+                disabled={downloading}
+                className="text-xs text-muted text-center underline underline-offset-2
+                           cursor-pointer hover:text-foreground transition-colors"
+              >
+                Don't ask about updates again
+              </button>
+            </ModalFooter>
+          </ModalDialog>
+        </ModalContainer>
+      </ModalBackdrop>
+    </Modal>
+  );
+}
+
+/**
+ * Renders the release notes for one or more versions in a scrollable list,
+ * newest first. Each version is labelled only when more than one is shown, so
+ * a single update doesn't repeat the version already named in the header.
+ */
+function Changelog({ releases }: { releases: ReleaseNotes[] }) {
+  return (
+    <div className="flex flex-col gap-4 max-h-72 overflow-y-auto rounded-lg
+                    bg-default/40 px-4 py-3 text-sm">
+      { releases.map((release, i) => (
+        <section key={release.tag} className="flex flex-col gap-1.5">
+          { releases.length > 1 &&
+            <h3 className="text-base font-semibold tracking-tight text-foreground">
+              Version {release.version}
+            </h3>
+          }
+
+          { release.notes.length > 0
+            ? <ReleaseNotesBody notes={release.notes} />
+            : <p className="text-muted italic">No release notes were provided.</p>
+          }
+
+          { i < releases.length - 1 &&
+            <hr className="mt-2 border-default" />
+          }
+        </section>
+      )) }
+    </div>
+  );
+}
+
+/**
+ * A minimal markdown renderer for GitHub release bodies. It covers the small
+ * subset those bodies actually use: headings, bullet lists, paragraphs, and
+ * inline bold, code, links, and bare URLs. Anything fancier is shown verbatim.
+ */
+function ReleaseNotesBody({ notes }: { notes: string }) {
+  const blocks: React.ReactNode[] = [];
+  const lines = notes.split(/\r?\n/);
+
+  let bullets: string[] = [];
+  const flushBullets = () => {
+    if (bullets.length == 0)
+      return;
+
+    const items = bullets;
+    bullets = [];
+    blocks.push(
+      <ul key={`ul-${blocks.length}`} className="flex flex-col gap-1 pl-4 list-disc marker:text-muted">
+        { items.map((item, i) => <li key={i}>{renderInline(item)}</li>) }
+      </ul>
+    );
+  };
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+
+    if (line.trim() == "") {
+      flushBullets();
+      continue;
+    }
+
+    const bullet = line.match(/^\s*[-*]\s+(.*)$/);
+    if (bullet != null) {
+      bullets.push(bullet[1]);
+      continue;
+    }
+
+    flushBullets();
+
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading != null) {
+      blocks.push(
+        <h4 key={`h-${blocks.length}`} className="font-semibold text-foreground">
+          {renderInline(heading[2])}
+        </h4>
+      );
+      continue;
+    }
+
+    blocks.push(
+      <p key={`p-${blocks.length}`} className="text-foreground/90">
+        {renderInline(line)}
+      </p>
+    );
+  }
+
+  flushBullets();
+
+  return <div className="flex flex-col gap-2">{blocks}</div>;
+}
+
+// Matches, in order: **bold**, `code`, [text](url), and bare http(s) URLs.
+const INLINE_PATTERN = /(\*\*([^*]+)\*\*)|(`([^`]+)`)|(\[([^\]]+)\]\(([^)]+)\))|(https?:\/\/\S+)/g;
+
+function renderInline(text: string): React.ReactNode {
+  const nodes: React.ReactNode[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  INLINE_PATTERN.lastIndex = 0;
+  while ((match = INLINE_PATTERN.exec(text)) != null) {
+    if (match.index > last)
+      nodes.push(<Fragment key={key++}>{text.slice(last, match.index)}</Fragment>);
+
+    if (match[2] != null) {
+      nodes.push(<strong key={key++} className="font-semibold text-foreground">{match[2]}</strong>);
+    } else if (match[4] != null) {
+      nodes.push(
+        <code key={key++} className="rounded bg-default px-1 py-0.5 font-mono text-[0.85em]">
+          {match[4]}
+        </code>
+      );
+    } else if (match[6] != null) {
+      nodes.push(<ExternalLink key={key++} href={match[7]}>{match[6]}</ExternalLink>);
+    } else if (match[8] != null) {
+      nodes.push(<ExternalLink key={key++} href={match[8]}>{shortenUrl(match[8])}</ExternalLink>);
+    }
+
+    last = INLINE_PATTERN.lastIndex;
+  }
+
+  if (last < text.length)
+    nodes.push(<Fragment key={key++}>{text.slice(last)}</Fragment>);
+
+  return nodes;
+}
+
+/** Drops the scheme and any trailing slash so bare URLs read less noisily. */
+function shortenUrl(url: string) {
+  return url.replace(/^https?:\/\//, "").replace(/\/$/, "");
+}
+
+/** A link that opens in the system browser rather than navigating the webview. */
+function ExternalLink({ href, children }: { href: string, children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      onClick={e => { e.preventDefault(); open(href).catch(() => {}); }}
+      className="text-primary underline underline-offset-2 hover:opacity-80"
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/ui/components/UpdateModal.tsx
+++ b/src/ui/components/UpdateModal.tsx
@@ -35,6 +35,13 @@ export default function UpdateModal({ update, onDismiss }: {
     try {
       // If this succeeds, the installer is running and the app is about to exit.
       await installUpdate(update);
+
+      // When there's no installer for this platform, `installUpdate` just opens
+      // the release page in the browser and returns without exiting the app.
+      // Dismiss the (otherwise un-closable) dialog instead of leaving it stuck
+      // showing "Downloading...".
+      if (update.installerUrl == null)
+        onDismiss();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setDownloading(false);

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,0 +1,178 @@
+import { invoke } from "@tauri-apps/api/core";
+import { getVersion } from "@tauri-apps/api/app";
+import { open } from "@tauri-apps/plugin-shell";
+import { cfg, mutateCfg } from "./config";
+import { IN_TAURI } from "./native";
+
+/**
+ * The release notes for a single version, shown in the update dialog's changelog.
+ */
+export interface ReleaseNotes {
+  /** The version these notes describe, e.g. "1.2.0". */
+  version: string;
+
+  /** The release tag, e.g. "v1.2.0". */
+  tag: string;
+
+  /** The raw markdown body of the GitHub release. May be empty. */
+  notes: string;
+}
+
+/**
+ * Describes an available update, as determined by `checkForUpdates`.
+ */
+export interface UpdateInfo {
+  /** The version of the update, e.g. "1.2.0". */
+  version: string;
+
+  /** The release tag of the update, e.g. "v1.2.0". */
+  tag: string;
+
+  /** The version we're currently running, e.g. "1.1.1". */
+  currentVersion: string;
+
+  /** The GitHub page of the release, for manual downloads. */
+  releaseUrl: string;
+
+  /** The download URL of the installer for this platform, or `null` if none was found. */
+  installerUrl: string | null;
+
+  /**
+   * The release notes for every version between the one we're running and the
+   * update, newest first, so the user can see everything they've missed.
+   */
+  changelog: ReleaseNotes[];
+}
+
+interface GithubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GithubRelease {
+  tag_name: string;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+  body: string | null;
+  assets: GithubReleaseAsset[];
+}
+
+function parseVersion(version: string) {
+  return version.replace(/^v/, "").split(".").map(x => parseInt(x, 10) || 0);
+}
+
+/** Orders two version strings: negative if `a` < `b`, positive if `a` > `b`. */
+function compareVersions(a: string, b: string) {
+  const x = parseVersion(a);
+  const y = parseVersion(b);
+
+  for (let i = 0; i < Math.max(x.length, y.length); i++) {
+    const diff = (x[i] ?? 0) - (y[i] ?? 0);
+    if (diff != 0)
+      return diff;
+  }
+
+  return 0;
+}
+
+function isNewer(candidate: string, current: string) {
+  return compareVersions(candidate, current) > 0;
+}
+
+/**
+ * Picks the release asset that is an installer for the current platform,
+ * most preferred format first. Returns `null` if the release has none.
+ */
+function pickInstaller(assets: GithubReleaseAsset[]) {
+  const ua = navigator.userAgent;
+
+  const preferences: ((name: string) => boolean)[] =
+    ua.includes("Windows") ? [x => x.endsWith("-setup.exe"), x => x.endsWith(".msi")]
+    : ua.includes("Mac") ? [x => x.endsWith(".dmg")]
+    : [x => x.endsWith(".AppImage"), x => x.endsWith(".deb")];
+
+  for (const matches of preferences) {
+    const asset = assets.find(x => matches(x.name));
+    if (asset != null)
+      return asset.browser_download_url;
+  }
+
+  return null;
+}
+
+/**
+ * Checks GitHub for a newer release of Splicedd. Returns `null` when we're
+ * up to date, when update checks are disabled, or when the user chose to
+ * skip the latest version.
+ */
+// /src-tauri/src/updater.rs
+export async function checkForUpdates(): Promise<UpdateInfo | null> {
+  if (!IN_TAURI || !cfg().checkUpdates)
+    return null;
+
+  const releases = await invoke<GithubRelease[]>("fetch_releases");
+
+  // Only stable releases are offered as updates, newest first.
+  const stable = releases
+    .filter(x => !x.draft && !x.prerelease)
+    .sort((a, b) => compareVersions(b.tag_name, a.tag_name));
+
+  const latest = stable[0];
+  if (latest == null)
+    return null;
+
+  if (latest.tag_name == cfg().skippedUpdateVersion)
+    return null;
+
+  const currentVersion = await getVersion();
+  if (!isNewer(latest.tag_name, currentVersion))
+    return null;
+
+  const changelog: ReleaseNotes[] = stable
+    .filter(x => isNewer(x.tag_name, currentVersion))
+    .map(x => ({
+      version: x.tag_name.replace(/^v/, ""),
+      tag: x.tag_name,
+      notes: (x.body ?? "").trim()
+    }));
+
+  return {
+    version: latest.tag_name.replace(/^v/, ""),
+    tag: latest.tag_name,
+    currentVersion,
+    releaseUrl: latest.html_url,
+    installerUrl: pickInstaller(latest.assets),
+    changelog
+  };
+}
+
+/**
+ * Downloads and launches the installer for the given update, terminating
+ * Splicedd if successful. If no installer is available for this platform,
+ * opens the release page in the browser instead.
+ */
+// /src-tauri/src/updater.rs
+export async function installUpdate(update: UpdateInfo) {
+  if (update.installerUrl == null) {
+    await open(update.releaseUrl);
+    return;
+  }
+
+  await invoke("install_update", { url: update.installerUrl });
+}
+
+/**
+ * Stops the given update from being suggested again. Newer versions will
+ * still be suggested.
+ */
+export async function skipUpdate(update: UpdateInfo) {
+  await mutateCfg({ skippedUpdateVersion: update.tag });
+}
+
+/**
+ * Disables update checks entirely. Can be re-enabled from the settings.
+ */
+export async function disableUpdateChecks() {
+  await mutateCfg({ checkUpdates: false });
+}


### PR DESCRIPTION
Checks GitHub for newer releases and offers to install them, showing extracted release notes for each missed version. Adds a settings toggle to disable checks.