### PR TITLE
feat: refine search and filter UI

### DIFF
--- a/src/splice/entities.ts
+++ b/src/splice/entities.ts
@@ -11,3 +11,19 @@ export type MusicKey = "C" | "C#" | "D" | "D#" | "E" | "F" | "F#" | "G" | "G#" |
 
 export type ChordType = "major" | "minor";
 
+const CHROMATIC: MusicKey[] = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+/**
+ * Returns the relative major/minor of the given key — the key that shares the
+ * same set of pitches (e.g. C Major ↔ A Minor). The relative major of a minor
+ * key sits a minor third (three semitones) above it, and vice versa.
+ */
+export function relativeKey(key: MusicKey, chord: ChordType): { key: MusicKey, chord: ChordType } {
+  const i = CHROMATIC.indexOf(key);
+  const shift = chord == "minor" ? 3 : 9; // +3 semitones up (minor→major), or -3 down (major→minor)
+  return {
+    key: CHROMATIC[(i + shift) % 12],
+    chord: chord == "minor" ? "major" : "minor"
+  };
+}
+

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 import { Button, ListBox, ListBoxItem, ListBoxItemIndicator, ModalBackdrop, ModalCloseTrigger, ModalContainer, ModalDialog, Pagination, PaginationContent, PaginationEllipsis, PaginationItem, PaginationLink, PaginationNext, PaginationNextIcon, PaginationPrevious, PaginationPreviousIcon, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle, ToggleButton, useOverlayState } from "@heroui/react";
-import { InputGroup, InputGroupInput, InputGroupPrefix, Modal, Popover, PopoverContent, PopoverDialog, Select, SelectIndicator, SelectPopover, SelectTrigger, SelectValue } from "@heroui/react";
-import { ArrowUpDown, ChevronDown, Disc3, EllipsisVertical, Guitar, Layers, Metronome, Music2, Search, Wrench, X } from "lucide-react";
+import { InputGroup, InputGroupInput, InputGroupPrefix, InputGroupSuffix, Modal, Popover, PopoverContent, PopoverDialog, Select, SelectIndicator, SelectPopover, SelectTrigger, SelectValue } from "@heroui/react";
+import { ArrowUpDown, ChevronDown, Disc3, EllipsisVertical, Guitar, Layers, Metronome, MoveRight, Music2, Repeat, Search, Wrench, X } from "lucide-react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { cfg } from "../config";
 import { SpliceSample, SpliceSamplePack, SpliceSearchResponse, createSearchRequest } from "../splice/api";
@@ -88,12 +88,11 @@ function App() {
   const [query, setQuery] = useState("");
 
   const [results, setResults] = useState<SpliceSample[]>([]);
-  const [resultCount, setResultCount] = useState(0);
   const resultContainer = useRef<HTMLDivElement | null>(null);
 
   const [queryTimer, setQueryTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
 
-  const [sortBy, setSortBy] = useState<SpliceSortBy>("relevance");
+  const [sortBy, setSortBy] = useState<SpliceSortBy>("popularity");
   const [sampleType, setSampleType] = useState<SpliceSampleType | "any">("any")
 
   const [knownInstruments, setKnownInstruments] = useState<{name: string, uuid: string}[]>([]);
@@ -145,6 +144,14 @@ function App() {
     cancellation: smplCancellation,
     setCancellation: smplSetCancellation
   }
+
+  // Stop any playing sample when the window loses focus (e.g. the user tabs
+  // away or drags a sample into their DAW).
+  useEffect(() => {
+    const stopOnBlur = () => smplCancellation?.();
+    window.addEventListener("blur", stopOnBlur);
+    return () => window.removeEventListener("blur", stopOnBlur);
+  }, [smplCancellation]);
 
   function ensureContraintsGathered() {
     if (knownInstruments.length == 0 || knownGenres.length == 0) {
@@ -257,7 +264,6 @@ function App() {
       const data = respData.data.assetsSearch;
 
       setResults(data.items);
-      setResultCount(data.response_metadata.records);
 
       setCurrentPage(resetPage ? 1 : data.pagination_metadata.currentPage);
       setTotalPages(data.pagination_metadata.totalPages);
@@ -311,12 +317,23 @@ function App() {
             onKeyDown={handleSearchKeyDown}
             onChange={handleSearchInput}
           />
+          { searchLoading &&
+            <InputGroupSuffix>
+              <ProgressCircle aria-label="Loading results..." isIndeterminate className="size-5">
+                <ProgressCircleTrack>
+                  <ProgressCircleTrackCircle />
+                  <ProgressCircleFillCircle />
+                </ProgressCircleTrack>
+              </ProgressCircle>
+            </InputGroupSuffix>
+          }
         </InputGroup>
 
         <Select
           aria-label="Sort by"
           value={sortBy}
           onChange={v => setSortBy(v as SpliceSortBy)}
+          className="w-48"
         >
           <SelectTrigger>
             <ArrowUpDown className="size-4 me-2 self-center shrink-0 text-muted" />
@@ -442,14 +459,24 @@ function App() {
         >
           <SelectTrigger>
             <Layers className="size-4 me-2 self-center shrink-0 text-muted" />
-            <SelectValue />
+            { /* Render only the label here; the per-item icons belong in the dropdown. */ }
+            <SelectValue>{({ selectedText }) => selectedText}</SelectValue>
             <SelectIndicator />
           </SelectTrigger>
           <SelectPopover>
             <ListBox>
-              <ListBoxItem id="any" textValue="Any">Any<ListBoxItemIndicator /></ListBoxItem>
-              <ListBoxItem id="oneshot" textValue="One-Shots">One-Shots<ListBoxItemIndicator /></ListBoxItem>
-              <ListBoxItem id="loop" textValue="Loops">Loops<ListBoxItemIndicator /></ListBoxItem>
+              <ListBoxItem id="any" textValue="Any">
+                <span className="size-4 shrink-0" aria-hidden="true" />
+                Any<ListBoxItemIndicator />
+              </ListBoxItem>
+              <ListBoxItem id="oneshot" textValue="One-Shots">
+                <MoveRight className="size-4 shrink-0 text-muted" />
+                One-Shots<ListBoxItemIndicator />
+              </ListBoxItem>
+              <ListBoxItem id="loop" textValue="Loops">
+                <Repeat className="size-4 shrink-0 text-muted" />
+                Loops<ListBoxItemIndicator />
+              </ListBoxItem>
             </ListBox>
           </SelectPopover>
         </Select>
@@ -458,7 +485,7 @@ function App() {
       { (query.length > 0 || filtersActive) && knownTags.length > 0 &&
         <div className="flex items-start gap-2">
           { /* Selected tags are pinned to the front; the rest follow, most popular first. */ }
-          <div className={`flex-1 min-w-0 flex flex-wrap gap-2 ${tagsExpanded ? "" : "h-9 md:h-8 overflow-hidden"}`}>
+          <div className={`flex-1 min-w-0 flex flex-wrap gap-1.5 ${tagsExpanded ? "" : "h-9 md:h-8 overflow-hidden"}`}>
             { [...tags, ...knownTags.filter(x => !tags.some(y => y.uuid == x.uuid))].map(x =>
               <ToggleButton key={x.uuid} size="sm" className={TAG_PILL_CLASSES}
                 isSelected={tags.some(y => y.uuid == x.uuid)}
@@ -528,24 +555,6 @@ function App() {
         : <div ref={resultContainer}
             className="flex-1 min-h-0 mt-2 overflow-y-auto scrollbar-thin shadow-md bg-surface p-6 rounded-3xl flex flex-col gap-6"
         >
-              <div className="flex justify-between items-start">
-                <div className="space-y-1">
-                  <h4 className="text-base font-medium">Samples</h4>
-                  <p className="text-sm text-muted">
-                    Found {resultCount.toLocaleString("en-US")} sample{resultCount != 1 ? "s" : ""} in total.
-                  </p>
-                </div>
-
-                <div> { searchLoading &&
-                  <ProgressCircle aria-label="Loading results..." isIndeterminate>
-                    <ProgressCircleTrack>
-                      <ProgressCircleTrackCircle />
-                      <ProgressCircleFillCircle />
-                    </ProgressCircleTrack>
-                  </ProgressCircle>
-                } </div>
-              </div>
-
               <div className={`flex-1 flex flex-col transition-opacity duration-150
                               ${searchLoading ? "opacity-50 pointer-events-none" : ""}`}
               >

--- a/src/ui/components/BpmSelection.tsx
+++ b/src/ui/components/BpmSelection.tsx
@@ -66,7 +66,7 @@ export default function BpmSelection({
   );
 
   const bottomRow = () => (
-    <div className="flex justify-between items-center w-full pt-2">
+    <div className="flex justify-between items-center w-full pt-1">
       <Link href="#" onClick={onClear}>Clear</Link>
       <Button isDisabled={!canSave} onClick={handleSave}>Save</Button>
     </div>
@@ -100,8 +100,8 @@ export default function BpmSelection({
         <Tab id="exact" className="flex-1 justify-center">Exact<TabIndicator /></Tab>
       </TabList>
 
-      <TabPanel id="range">
-        <div className="flex flex-col gap-4 pt-4">
+      <TabPanel id="range" className="mt-0!">
+        <div className="flex flex-col gap-2 pt-3">
           <div className="flex justify-between items-center">
             <h4 className="text-base font-medium">Range</h4>
             <div className="flex items-center gap-2">
@@ -133,8 +133,8 @@ export default function BpmSelection({
         </div>
       </TabPanel>
 
-      <TabPanel id="exact">
-        <div className="flex flex-col gap-4 pt-4">
+      <TabPanel id="exact" className="mt-0!">
+        <div className="flex flex-col gap-2 pt-3">
           <div className="flex justify-between items-center">
             <h4 className="text-base font-medium">Exact</h4>
             {bpmInput(exactBpm, setExactBpm, "BPM")}

--- a/src/ui/components/KeyScaleSelection.tsx
+++ b/src/ui/components/KeyScaleSelection.tsx
@@ -1,5 +1,5 @@
 import { Button, Link } from "@heroui/react";
-import { ChordType, MusicKey } from "../../splice/entities";
+import { ChordType, MusicKey, relativeKey } from "../../splice/entities";
 
 export default function KeyScaleSelection({
   selectedKey, selectedChord, onKeySet, onChordSet
@@ -59,7 +59,21 @@ export default function KeyScaleSelection({
         { chordButton("minor", "Minor") }
       </div>
 
-      <div className="flex justify-start pt-2">
+      { /* Swap to the relative major/minor — the key sharing the same pitches
+           (e.g. A Minor ↔ C Major). Needs both a key and a scale. */ }
+      { selectedKey != null && selectedChord != null &&
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => {
+            const rel = relativeKey(selectedKey, selectedChord);
+            onKeySet(rel.key);
+            onChordSet(rel.chord);
+          }}
+        >Make relative</Button>
+      }
+
+      <div className="flex items-center justify-end pt-2">
         <Link href="#" onClick={() => { onChordSet(null); onKeySet(null) }}>Clear</Link>
       </div>
     </div>

--- a/src/ui/components/KeyScaleSelection.tsx
+++ b/src/ui/components/KeyScaleSelection.tsx
@@ -59,22 +59,24 @@ export default function KeyScaleSelection({
         { chordButton("minor", "Minor") }
       </div>
 
-      { /* Swap to the relative major/minor — the key sharing the same pitches
-           (e.g. A Minor ↔ C Major). Needs both a key and a scale. */ }
-      { selectedKey != null && selectedChord != null &&
-        <Button
-          variant="outline"
-          className="w-full"
-          onClick={() => {
-            const rel = relativeKey(selectedKey, selectedChord);
-            onKeySet(rel.key);
-            onChordSet(rel.chord);
-          }}
-        >Make relative</Button>
-      }
+      <div className="flex items-center pt-2">
+        { /* Swap to the relative major/minor — the key sharing the same pitches
+             (e.g. A Minor ↔ C Major). Needs both a key and a scale. */ }
+        { selectedKey != null && selectedChord != null &&
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const rel = relativeKey(selectedKey, selectedChord);
+              onKeySet(rel.key);
+              onChordSet(rel.chord);
+            }}
+          >Make relative</Button>
+        }
 
-      <div className="flex items-center justify-end pt-2">
-        <Link href="#" onClick={() => { onChordSet(null); onKeySet(null) }}>Clear</Link>
+        { (selectedKey != null || selectedChord != null) &&
+          <Link href="#" className="ml-auto" onClick={() => { onChordSet(null); onKeySet(null) }}>Clear</Link>
+        }
       </div>
     </div>
   )

--- a/src/ui/components/SampleListEntry.tsx
+++ b/src/ui/components/SampleListEntry.tsx
@@ -256,7 +256,7 @@ export default function SampleListEntry(
             <div className="flex flex-col gap-2 p-3 max-w-40">
               <img src={packCover} alt={pack.name} width={128} height={128} className="rounded-lg" />
               <span className="text-sm font-medium">{pack.name}</span>
-              <span className="text-xs text-muted">Click to show samples from this pack</span>
+              <span className="text-xs text-muted text-balance">Click to show samples from this pack</span>
             </div>
           </TooltipContent>
         </Tooltip>

--- a/src/ui/components/SettingsModalContent.tsx
+++ b/src/ui/components/SettingsModalContent.tsx
@@ -65,7 +65,7 @@ export default function SettingsModalContent({ onClose }: { onClose: () => void 
         </div>
       </ModalHeader>
 
-      <ModalBody>
+      <ModalBody className="mt-4">
         <div className="divide-y divide-separator">
           <SettingRow
             title="Sample folder"


### PR DESCRIPTION
Adds a relative-key swap to the key filter, one-shot/loop icons, popularity-first sorting, and various spacing fixes. Stops sample playback when the window loses focus.