### PR TITLE
fix: persist sample folder configuration across restarts

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -20,10 +20,6 @@
       "allow": [{ "path": "$APPCONFIG/**" }]
     },
     {
-      "identifier": "fs:allow-mkdir",
-      "allow": [{ "path": "$APPCONFIG/**" }]
-    },
-    {
       "identifier": "http:default",
       "allow": [
         { "url": "https://spliceproduction.s3.*.amazonaws.com/**" },

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,7 @@
 mod files;
 mod updater;
 
-use tauri::{WebviewUrl, WebviewWindowBuilder};
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
 // Splice's GraphQL endpoint sits behind Cloudflare Bot Management, which rejects
 // any client whose TLS/HTTP2 fingerprint isn't a real browser (Tauri's built-in
@@ -99,6 +99,10 @@ fn main() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())
         .setup(|app| {
+            // Create this before the frontend starts. The config loader and
+            // writer can then safely access config.json through the fs plugin.
+            std::fs::create_dir_all(app.path().app_config_dir()?)?;
+
             WebviewWindowBuilder::new(
                 app,
                 SPLICE_HELPER_LABEL,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
-import { exists, readTextFile, writeTextFile, mkdir } from "@tauri-apps/plugin-fs";
-import { BaseDirectory, appConfigDir } from "@tauri-apps/api/path";
+import { exists, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { BaseDirectory } from "@tauri-apps/api/path";
 import { useState } from "react";
 import { IN_TAURI } from "./native";
 
@@ -19,6 +19,8 @@ export interface SpliceddConfig {
 }
 
 let globalCfg: SpliceddConfig;
+let saveQueue: Promise<void> = Promise.resolve();
+
 function defaultCfg(): SpliceddConfig {
   return {
     sampleDir: "",
@@ -56,17 +58,20 @@ export async function loadConfig() {
     return;
   }
 
-  const appConfig = await appConfigDir();
-  await mkdir(appConfig, { recursive: true }).catch(() => {});
+  globalCfg = defaultCfg();
 
-  if (!await exists("config.json", { baseDir: BaseDirectory.AppConfig })) {
-    globalCfg = defaultCfg();
-  } else {
+  try {
+    if (!await exists("config.json", { baseDir: BaseDirectory.AppConfig }))
+      return;
+
     const raw = await readTextFile("config.json", {
       baseDir: BaseDirectory.AppConfig,
     });
-
     globalCfg = { ...defaultCfg(), ...JSON.parse(raw) };
+  } catch (err) {
+    // A missing, unreadable, or malformed config must never prevent the UI
+    // from mounting. Keep the defaults and allow the next save to repair it.
+    console.error("failed to load config; using defaults:", err);
   }
 }
 
@@ -77,9 +82,18 @@ export async function saveConfig() {
   if (!IN_TAURI)
     return;
 
-  await writeTextFile("config.json", JSON.stringify(globalCfg, null, 2), {
-    baseDir: BaseDirectory.AppConfig
-  });
+  // Keep writes ordered. Settings controls can update in quick succession and
+  // concurrent writeTextFile calls can otherwise leave an older snapshot on
+  // disk after a newer one has completed.
+  const serialized = JSON.stringify(globalCfg, null, 2);
+  const write = saveQueue
+    .catch(() => {}) // a failed write must not prevent later retries
+    .then(() => writeTextFile("config.json", serialized, {
+      baseDir: BaseDirectory.AppConfig
+    }));
+
+  saveQueue = write;
+  await write;
 }
 
 /**
@@ -106,5 +120,5 @@ export function useCfgSyncedState<T>(key: keyof SpliceddConfig) {
 export function mutateCfgSync<T>(value: T, state: ConfigSyncedState<T>) {
   (globalCfg as any)[state.key] = value;
   state.setState(value);
-  saveConfig();
+  return saveConfig();
 }

--- a/src/ui/components/SettingsModalContent.tsx
+++ b/src/ui/components/SettingsModalContent.tsx
@@ -37,8 +37,10 @@ export default function SettingsModalContent({ onClose }: { onClose: () => void 
   const darkMode = useCfgSyncedState<boolean>("darkMode");
   const checkUpdates = useCfgSyncedState<boolean>("checkUpdates");
 
-  function closeFirstTimeSetup() {
-    mutateCfg({ configured: true });
+  async function closeFirstTimeSetup() {
+    // Do not dismiss setup until both the folder and configured flag are on
+    // disk. mutateCfg waits behind any pending folder write.
+    await mutateCfg({ configured: true });
     onClose();
   }
 


### PR DESCRIPTION
Tested on Windows 11, version 25H2, build 26200.9168 
Fixes #26 